### PR TITLE
Swapped ApplyFieldSpeeds to ApplyRobotSpeeds

### DIFF
--- a/src/main/java/com/team2813/subsystems/Drive.java
+++ b/src/main/java/com/team2813/subsystems/Drive.java
@@ -143,10 +143,18 @@ public class Drive extends SubsystemBase {
     private double getPosition(int moduleId) {
         return drivetrain.getModule(moduleId).getEncoder().getAbsolutePosition().getValue().in(Rotations);
     }
-    private final ApplyRobotSpeeds ApplyRobotSpeedsApplier = new ApplyRobotSpeeds(); // Looks stupid, but ApplyRobotSpeeds needs to be instanced.
-    private final FieldCentricFacingAngle fieldCentricFacingAngleApplier = new FieldCentricFacingAngle(); // Same as above
+    private final ApplyRobotSpeeds applyRobotSpeedsApplier = new ApplyRobotSpeeds();
+    /*
+     * IT IS ABSOLUTELY IMPERATIVE THAT YOU USE ApplyRobotSpeeds() RATHER THAN THE DEMENTED ApplyFieldSpeeds() HERE!
+     * If ApplyFieldSpeeds() is used, pathplanner & all autonomus paths will not function properly.
+     * This is because pathplanner knows where the robot is, but needs to use ApplyRobotSpeeds() in order to convert knowledge
+     * of where the robot is on the field, to instruction centered on the robot.
+     * Or something like this, I'm still not too sure how this works.
+     */
+    private final FieldCentricFacingAngle fieldCentricFacingAngleApplier = new FieldCentricFacingAngle();
     private final FieldCentric fieldCentricApplier = new FieldCentric().withDriveRequestType(SwerveModule.DriveRequestType.Velocity);
 
+    // Note: This is used for teleop drive.
     public void drive(double xSpeed, double ySpeed, double rotation) {
         drivetrain.setControl(fieldCentricApplier
             .withVelocityX(xSpeed * multiplier)
@@ -159,8 +167,9 @@ public class Drive extends SubsystemBase {
         drivetrain.setControl(request);
     }
     
+    // Note: This is used for auto drive. 
     public void drive(ChassisSpeeds demand) {
-        drivetrain.setControl(ApplyRobotSpeedsApplier.withSpeeds(demand));
+        drivetrain.setControl(applyRobotSpeedsApplier.withSpeeds(demand));
     }
 
     public void turnToFace(Rotation2d rotation) {


### PR DESCRIPTION
By swapping all references of `ApplyFieldSpeeds` to `ApplyRobotSpeeds`, Auto should be fixed. We likely need some documentation in this file to make sure this issue does not occur again.