### PR TITLE
Call configureAuto() after configureAutoCommands()

### DIFF
--- a/src/main/java/com/team2813/RobotContainer.java
+++ b/src/main/java/com/team2813/RobotContainer.java
@@ -50,9 +50,7 @@ public class RobotContainer implements AutoCloseable {
     this.drive = new Drive(shuffleboard);
     this.elevator = new Elevator(shuffleboard);
     this.intakePivot = new IntakePivot(shuffleboard);
-    autoChooser = configureAuto(this.drive);
 
-    SmartDashboard.putData("Auto Routine", autoChooser);
     drive.setDefaultCommand(
             new DefaultDriveCommand(
                     drive,
@@ -63,7 +61,8 @@ public class RobotContainer implements AutoCloseable {
     RobotCommands autoCommands = new RobotCommands(intake, intakePivot, elevator);
     configureBindings(autoCommands);
     configureAutoCommands(autoCommands);
-
+    autoChooser = configureAuto(this.drive);
+    SmartDashboard.putData("Auto Routine", autoChooser);
   }
   
   /**


### PR DESCRIPTION
This fixes a problem where the following message is sent to the driver station:

> PathPlanner attempted to create a command 'name' that has not been
> registered with NamedCommands.registerCommand

I tried to find some way I could write a test to verify the bug and the fix, but the only way I could think of would require either using reflection to access private fields or to parse the Path Planner JSON file myself to find the commands so we could ensure they are all registered (and due to static state, I'm not even sure I could verify this only by parsing the JSON).
