### PR TITLE
Publish vision locations even if we don't call addVisionMeasurement()

### DIFF
--- a/src/main/java/com/team2813/subsystems/Drive.java
+++ b/src/main/java/com/team2813/subsystems/Drive.java
@@ -474,6 +474,10 @@ public class Drive extends SubsystemBase implements AutoCloseable {
       NetworkTableInstance.getDefault().getDoubleTopic("Ambiguity").publish();
 
   private void handlePhotonPose(EstimatedRobotPose estimate) {
+    if (!config.usePhotonVisionLocation) {
+      return;
+    }
+
     Matrix<N3, N1> stdDevs;
     List<PhotonTrackedTarget> targets = estimate.targetsUsed;
     if (targets.isEmpty()) {
@@ -515,9 +519,7 @@ public class Drive extends SubsystemBase implements AutoCloseable {
     // Publish data to NetworkTables
     expectedState.set(drivetrain.getState().ModuleTargets);
     actualState.set(drivetrain.getState().ModuleStates);
-    if (config.usePhotonVisionLocation) {
-      photonPoseEstimator.update(this::handlePhotonPose);
-    }
+    photonPoseEstimator.update(this::handlePhotonPose);
     Pose2d pose = getPose();
     currentPose.set(pose);
     photonPoseEstimator.setDrivePose(pose);


### PR DESCRIPTION
This allows us to see the estimated positions in AdvantageScope even if the
current configuration specified that the position should not be passed along
to `SwerveDrivetrain.addVisionMeasurement()`.

Tested in the simulator.