### PR TITLE
Move pose estimate topics to a separate network table

### DIFF
--- a/AdvantageScope-simulator.json
+++ b/AdvantageScope-simulator.json
@@ -1,0 +1,157 @@
+{
+  "hubs": [
+    {
+      "x": 206,
+      "y": 110,
+      "width": 1100,
+      "height": 705,
+      "state": {
+        "sidebar": {
+          "width": 300,
+          "expanded": [
+            "/Drive",
+            "/photonvision/capt-barnacles",
+            "/photonvision/professor-inkling",
+            "/Vision",
+            "/Vision/capt-barnacles",
+            "/Vision/professor-inkling"
+          ]
+        },
+        "tabs": {
+          "selected": 2,
+          "tabs": [
+            {
+              "type": 0,
+              "title": "",
+              "controller": null,
+              "controllerUUID": "nj6f73qt9kq1i5h5sq1yf1nk3mlnro0i",
+              "renderer": "#/",
+              "controlsHeight": 0
+            },
+            {
+              "type": 1,
+              "title": "Line Graph",
+              "controller": {
+                "leftSources": [],
+                "rightSources": [],
+                "discreteSources": [],
+                "leftLockedRange": null,
+                "rightLockedRange": null,
+                "leftUnitConversion": {
+                  "type": null,
+                  "factor": 1
+                },
+                "rightUnitConversion": {
+                  "type": null,
+                  "factor": 1
+                },
+                "leftFilter": 0,
+                "rightFilter": 0
+              },
+              "controllerUUID": "tt706h1e2kiu25n9kics87pdkfi15pxu",
+              "renderer": null,
+              "controlsHeight": 200
+            },
+            {
+              "type": 2,
+              "title": "Odometry",
+              "controller": {
+                "sources": [
+                  {
+                    "type": "ghost",
+                    "logKey": "NT:/Drive/simulated pose",
+                    "logType": "Pose2d",
+                    "visible": true,
+                    "options": {
+                      "color": "#00ffff"
+                    }
+                  },
+                  {
+                    "type": "robot",
+                    "logKey": "NT:/Drive/current pose",
+                    "logType": "Pose2d",
+                    "visible": true,
+                    "options": {}
+                  },
+                  {
+                    "type": "vision",
+                    "logKey": "NT:/photonvision/capt-barnacles/targetPose",
+                    "logType": "Transform3d",
+                    "visible": true,
+                    "options": {
+                      "color": "#0000ff",
+                      "size": "normal"
+                    }
+                  },
+                  {
+                    "type": "vision",
+                    "logKey": "NT:/photonvision/professor-inkling/targetPose",
+                    "logType": "Transform3d",
+                    "visible": true,
+                    "options": {
+                      "color": "#ff8c00",
+                      "size": "normal"
+                    }
+                  },
+                  {
+                    "type": "ghost",
+                    "logKey": "NT:/Vision/professor-inkling/poseEstimate",
+                    "logType": "Pose3d",
+                    "visible": true,
+                    "options": {
+                      "color": "#ff8c00"
+                    }
+                  },
+                  {
+                    "type": "ghost",
+                    "logKey": "NT:/Vision/capt-barnacles/poseEstimate",
+                    "logType": "Pose3d",
+                    "visible": true,
+                    "options": {
+                      "color": "#0000ff"
+                    }
+                  }
+                ],
+                "game": "2025 Field (Welded)",
+                "bumpers": "blue",
+                "origin": "blue",
+                "orientation": 0,
+                "size": 30
+              },
+              "controllerUUID": "x212yd1n4lj9v9rugq74y5cfhfc1hv4v",
+              "renderer": null,
+              "controlsHeight": 200
+            },
+            {
+              "type": 3,
+              "title": "3D Field",
+              "controller": {
+                "sources": [],
+                "game": "2025 Field (Welded)",
+                "origin": "blue"
+              },
+              "controllerUUID": "ppuzl9vc7egzw84892jfc27u1z51sx18",
+              "renderer": {
+                "cameraIndex": -1,
+                "orbitFov": 50,
+                "cameraPosition": [
+                  0,
+                  0,
+                  0
+                ],
+                "cameraTarget": [
+                  0,
+                  0,
+                  0
+                ]
+              },
+              "controlsHeight": 200
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "satellites": [],
+  "version": "4.1.1"
+}

--- a/src/main/java/com/team2813/commands/RobotLocalization.java
+++ b/src/main/java/com/team2813/commands/RobotLocalization.java
@@ -171,8 +171,7 @@ public class RobotLocalization { // TODO: consider making this a subsystem so we
   private final LimelightPosePublisher limelightPosePublisher =
       new LimelightPosePublisher(NetworkTableInstance.getDefault());
   private final BooleanPublisher hasDataPublisher =
-      NetworkTableInstance.getDefault()
-          .getTable(LimelightPosePublisher.TABLE_NAME)
+      LimelightPosePublisher.getNetworkTable(NetworkTableInstance.getDefault())
           .getBooleanTopic("hasData")
           .publish();
 

--- a/src/main/java/com/team2813/subsystems/Drive.java
+++ b/src/main/java/com/team2813/subsystems/Drive.java
@@ -178,8 +178,8 @@ public class Drive extends SubsystemBase implements AutoCloseable {
                 aprilTagFieldLayout,
                 PhotonPoseEstimator.PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR)
             // should have named our batteries after Octonauts characters >:(
-            .addCamera("capt-barnacles", captBarnaclesTransform)
-            .addCamera("professor-inkling", professorInklingTransform)
+            .addCamera("capt-barnacles", captBarnaclesTransform, "Front PhotonVision camera")
+            .addCamera("professor-inkling", professorInklingTransform, "Back PhotonVision camera")
             .build();
     this.config = config;
 
@@ -294,8 +294,6 @@ public class Drive extends SubsystemBase implements AutoCloseable {
     visibleTargetPoses =
         networkTable.getStructArrayTopic("visible target poses", Pose3d.struct).publish();
     modulePositions = networkTable.getDoubleArrayTopic("module positions").publish();
-    captPose = networkTable.getStructTopic("Front cam pos", Pose3d.struct).publish();
-    professorPose = networkTable.getStructTopic("Back cam pos", Pose3d.struct).publish();
 
     setDefaultCommand(createDefaultCommand());
 
@@ -466,8 +464,6 @@ public class Drive extends SubsystemBase implements AutoCloseable {
   private final StructPublisher<Pose2d> currentPose;
   private final StructArrayPublisher<Pose3d> visibleTargetPoses;
   private final DoubleArrayPublisher modulePositions;
-  private final StructPublisher<Pose3d> captPose;
-  private final StructPublisher<Pose3d> professorPose;
   private static final Matrix<N3, N1> PHOTON_MULTIPLE_TAG_STD_DEVS =
       new Matrix<>(Nat.N3(), Nat.N1(), new double[] {0.1, 0.1, 0.1});
 
@@ -516,8 +512,7 @@ public class Drive extends SubsystemBase implements AutoCloseable {
     }
     Pose2d pose = getPose();
     currentPose.set(pose);
-    captPose.set(new Pose3d(pose).plus(captBarnaclesTransform));
-    professorPose.set(new Pose3d(pose).plus(professorInklingTransform));
+    photonPoseEstimator.setDrivePose(pose);
     Collection<Pose3d> visibleAprilTagPoses = locationalData.getVisibleAprilTagPoses().values();
     visibleTargetPoses.accept(visibleAprilTagPoses.toArray(EMPTY_LIST));
 

--- a/src/main/java/com/team2813/vision/LimelightPosePublisher.java
+++ b/src/main/java/com/team2813/vision/LimelightPosePublisher.java
@@ -3,6 +3,7 @@ package com.team2813.vision;
 import com.ctre.phoenix6.Utils;
 import com.team2813.lib2813.limelight.BotPoseEstimate;
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.StructTopic;
 import edu.wpi.first.units.Units;
@@ -11,7 +12,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 public final class LimelightPosePublisher {
-  public static final String TABLE_NAME = "limelight";
+  private static final String CAMERA_NAME = "limelight";
   private final TimestampedStructPublisher<Pose2d> publisher;
   private final double timestampOffset;
 
@@ -23,8 +24,12 @@ public final class LimelightPosePublisher {
     timestampOffset =
         clocks.fpgaTimestampSupplier().get() - clocks.currentTimestampSupplier().get();
     StructTopic<Pose2d> topic =
-        ntInstance.getTable(TABLE_NAME).getStructTopic("poseEstimate", Pose2d.struct);
+        getNetworkTable(ntInstance).getStructTopic("poseEstimate", Pose2d.struct);
     publisher = new TimestampedStructPublisher<>(topic, Pose2d.kZero, clocks.fpgaTimestampSupplier);
+  }
+
+  public static NetworkTable getNetworkTable(NetworkTableInstance ntInstance) {
+    return VisionUtil.getTableForCamera(ntInstance, CAMERA_NAME);
   }
 
   /**

--- a/src/main/java/com/team2813/vision/LimelightPosePublisher.java
+++ b/src/main/java/com/team2813/vision/LimelightPosePublisher.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 public final class LimelightPosePublisher {
-  private static final String CAMERA_NAME = "limelight";
+  static final String CAMERA_NAME = "limelight";
   private final TimestampedStructPublisher<Pose2d> publisher;
   private final double timestampOffset;
 

--- a/src/main/java/com/team2813/vision/MultiPhotonPoseEstimator.java
+++ b/src/main/java/com/team2813/vision/MultiPhotonPoseEstimator.java
@@ -110,8 +110,9 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
   }
 
   public void setDrivePose(Pose2d pose) {
+    Pose3d pose3d = new Pose3d(pose);
     for (CameraData cameraData : cameraDatas) {
-      cameraData.cameraPosePublisher.set(new Pose3d(pose).plus(cameraData.robotToCamera));
+      cameraData.cameraPosePublisher.set(pose3d.plus(cameraData.robotToCamera));
     }
   }
 

--- a/src/main/java/com/team2813/vision/PhotonVisionPosePublisher.java
+++ b/src/main/java/com/team2813/vision/PhotonVisionPosePublisher.java
@@ -1,6 +1,10 @@
 package com.team2813.vision;
 
+import static com.team2813.vision.VisionUtil.getTableForCamera;
+
 import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.StructTopic;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.wpilibj.Timer;
@@ -17,8 +21,9 @@ public final class PhotonVisionPosePublisher {
   }
 
   PhotonVisionPosePublisher(PhotonCamera camera, Supplier<Double> fpgaTimestampSupplier) {
-    StructTopic<Pose3d> topic =
-        camera.getCameraTable().getStructTopic("poseEstimate", Pose3d.struct);
+    NetworkTableInstance ntInstance = camera.getCameraTable().getInstance();
+    NetworkTable table = getTableForCamera(ntInstance, camera.getName());
+    StructTopic<Pose3d> topic = table.getStructTopic("poseEstimate", Pose3d.struct);
     publisher = new TimestampedStructPublisher<>(topic, Pose3d.kZero, fpgaTimestampSupplier);
   }
 

--- a/src/main/java/com/team2813/vision/PhotonVisionPosePublisher.java
+++ b/src/main/java/com/team2813/vision/PhotonVisionPosePublisher.java
@@ -4,7 +4,6 @@ import static com.team2813.vision.VisionUtil.getTableForCamera;
 
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.StructTopic;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.wpilibj.Timer;
@@ -21,8 +20,7 @@ public final class PhotonVisionPosePublisher {
   }
 
   PhotonVisionPosePublisher(PhotonCamera camera, Supplier<Double> fpgaTimestampSupplier) {
-    NetworkTableInstance ntInstance = camera.getCameraTable().getInstance();
-    NetworkTable table = getTableForCamera(ntInstance, camera.getName());
+    NetworkTable table = getTableForCamera(camera);
     StructTopic<Pose3d> topic = table.getStructTopic("poseEstimate", Pose3d.struct);
     publisher = new TimestampedStructPublisher<>(topic, Pose3d.kZero, fpgaTimestampSupplier);
   }

--- a/src/main/java/com/team2813/vision/VisionUtil.java
+++ b/src/main/java/com/team2813/vision/VisionUtil.java
@@ -1,0 +1,16 @@
+package com.team2813.vision;
+
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
+
+final class VisionUtil {
+  private static final String TABLE_NAME = "Vision";
+
+  static NetworkTable getTableForCamera(NetworkTableInstance ntInstance, String cameraName) {
+    return ntInstance.getTable(TABLE_NAME).getSubTable(cameraName);
+  }
+
+  private VisionUtil() {
+    throw new AssertionError("Not instantiable");
+  }
+}

--- a/src/main/java/com/team2813/vision/VisionUtil.java
+++ b/src/main/java/com/team2813/vision/VisionUtil.java
@@ -2,12 +2,17 @@ package com.team2813.vision;
 
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
+import org.photonvision.PhotonCamera;
 
 final class VisionUtil {
   private static final String TABLE_NAME = "Vision";
 
   static NetworkTable getTableForCamera(NetworkTableInstance ntInstance, String cameraName) {
     return ntInstance.getTable(TABLE_NAME).getSubTable(cameraName);
+  }
+
+  static NetworkTable getTableForCamera(PhotonCamera camera) {
+    return getTableForCamera(camera.getCameraTable().getInstance(), camera.getName());
   }
 
   private VisionUtil() {

--- a/src/test/java/com/team2813/vision/LimelightPosePublisherTest.java
+++ b/src/test/java/com/team2813/vision/LimelightPosePublisherTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 public class LimelightPosePublisherTest {
   private static final double FAKE_TIMESTAMP_OFFSET = 0.25;
   private static final Pose2d DEFAULT_POSE = new Pose2d(28, 13, Rotation2d.fromDegrees(45));
-  private static final String EXPECTED_TABLE_NAME = "limelight";
+  private static final String EXPECTED_TABLE_NAME = "Vision/limelight";
 
   @Rule public final NetworkTableResource networkTable = new NetworkTableResource();
 

--- a/src/test/java/com/team2813/vision/PhotonVisionPosePublisherTest.java
+++ b/src/test/java/com/team2813/vision/PhotonVisionPosePublisherTest.java
@@ -20,8 +20,8 @@ public class PhotonVisionPosePublisherTest {
   private static final Pose3d DEFAULT_POSE =
       new Pose3d(
           28, 13, 25, new Rotation3d(Math.toRadians(28), Math.toRadians(13), Math.toRadians(25)));
-  private static final String CAMERA_NAME = "Tweak";
-  private static final String EXPECTED_TABLE_NAME = "photonvision/Tweak";
+  private static final String CAMERA_NAME = "tweak";
+  private static final String EXPECTED_TABLE_NAME = "Vision/tweak";
 
   @Rule public final NetworkTableResource networkTable = new NetworkTableResource();
 


### PR DESCRIPTION
This ensures they won't conflict with data published by limelight or photonvision.

Changes:
- Add Vision topic
- Move PhotonVision and Limelight topics into the Vision table
- Export camera description to the network table

Tested in the simulator.