### PR TITLE
Migrate USE_PHOTON_VISION_LOCATION preference to DriveConfiguration

### DIFF
--- a/src/main/java/com/team2813/AllPreferences.java
+++ b/src/main/java/com/team2813/AllPreferences.java
@@ -1,8 +1,8 @@
 package com.team2813;
 
 import edu.wpi.first.wpilibj.Preferences;
+import java.util.Map;
 import java.util.function.BooleanSupplier;
-import java.util.function.DoubleSupplier;
 
 /**
  * Holder for all values stored in {@link Preferences} for the robot.
@@ -11,13 +11,27 @@ import java.util.function.DoubleSupplier;
  * edited, the updated values are persisted across reboots.
  */
 public class AllPreferences {
+  private static final Map<Key, String> LEGACY_BOOLEAN_PREFERENCES =
+      Map.of(
+          Key.USE_PHOTON_VISION_LOCATION,
+          "subsystems.Drive.DriveConfiguration.usePhotonVisionLocation");
+
+  static synchronized void migrateLegacyPreferences() {
+    for (var entry : LEGACY_BOOLEAN_PREFERENCES.entrySet()) {
+      String oldKey = entry.getKey().name();
+      String newKey = entry.getValue();
+      if (Preferences.containsKey(oldKey)) {
+        if (!Preferences.containsKey(newKey)) {
+          boolean value = Preferences.getBoolean(oldKey, false);
+          Preferences.initBoolean(newKey, value);
+        }
+        Preferences.remove(oldKey);
+      }
+    }
+  }
 
   public static BooleanSupplier useAutoAlignWaypoints() {
     return booleanPref(Key.USE_AUTO_ALIGN_WAYPOINTS, true);
-  }
-
-  public static BooleanSupplier usePhotonVisionLocation() {
-    return booleanPref(Key.USE_PHOTON_VISION_LOCATION, false);
   }
 
   private static BooleanSupplier booleanPref(Key key, boolean defaultValue) {
@@ -26,14 +40,6 @@ public class AllPreferences {
       Preferences.initBoolean(name, defaultValue);
     }
     return () -> Preferences.getBoolean(name, defaultValue);
-  }
-
-  private static DoubleSupplier doublePref(Key key, double defaultValue) {
-    String name = key.name();
-    if (!Preferences.containsKey(name)) {
-      Preferences.initDouble(name, defaultValue);
-    }
-    return () -> Preferences.getDouble(name, defaultValue);
   }
 
   private enum Key {

--- a/src/main/java/com/team2813/AllPreferences.java
+++ b/src/main/java/com/team2813/AllPreferences.java
@@ -2,6 +2,7 @@ package com.team2813;
 
 import edu.wpi.first.wpilibj.Preferences;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -16,6 +17,9 @@ public class AllPreferences {
           Key.USE_PHOTON_VISION_LOCATION,
           "subsystems.Drive.DriveConfiguration.usePhotonVisionLocation");
 
+  private static final Set<String> REMOVED_PREFERENCES =
+      Set.of("USE_LIMELIGHT_LOCATION", "DRIVE_ADD_LIMELIGHT_MEASUREMENT");
+
   static synchronized void migrateLegacyPreferences() {
     for (var entry : LEGACY_BOOLEAN_PREFERENCES.entrySet()) {
       String oldKey = entry.getKey().name();
@@ -26,6 +30,11 @@ public class AllPreferences {
           Preferences.initBoolean(newKey, value);
         }
         Preferences.remove(oldKey);
+      }
+    }
+    for (var key : REMOVED_PREFERENCES) {
+      if (Preferences.containsKey(key)) {
+        Preferences.remove(key);
       }
     }
   }

--- a/src/main/java/com/team2813/Robot.java
+++ b/src/main/java/com/team2813/Robot.java
@@ -23,6 +23,7 @@ public class Robot extends TimedRobot {
   private final RobotContainer m_robotContainer;
 
   public Robot() {
+    AllPreferences.migrateLegacyPreferences();
     m_robotContainer =
         new RobotContainer(new RealShuffleboardTabs(), NetworkTableInstance.getDefault());
   }

--- a/src/main/java/com/team2813/subsystems/Drive.java
+++ b/src/main/java/com/team2813/subsystems/Drive.java
@@ -19,7 +19,6 @@ import com.ctre.phoenix6.swerve.SwerveRequest.ApplyRobotSpeeds;
 import com.ctre.phoenix6.swerve.SwerveRequest.FieldCentric;
 import com.ctre.phoenix6.swerve.SwerveRequest.FieldCentricFacingAngle;
 import com.google.auto.value.AutoBuilder;
-import com.team2813.AllPreferences;
 import com.team2813.commands.DefaultDriveCommand;
 import com.team2813.commands.RobotLocalization;
 import com.team2813.lib2813.limelight.BotPoseEstimate;
@@ -103,6 +102,7 @@ public class Drive extends SubsystemBase implements AutoCloseable {
    */
   public record DriveConfiguration(
       boolean addLimelightMeasurement,
+      boolean usePhotonVisionLocation,
       double maxLimelightDifferenceMeters,
       DoubleSupplier maxRotationsPerSecond,
       DoubleSupplier maxVelocityInMetersPerSecond) {
@@ -125,6 +125,7 @@ public class Drive extends SubsystemBase implements AutoCloseable {
     public static Builder builder() {
       return new AutoBuilder_Drive_DriveConfiguration_Builder()
           .addLimelightMeasurement(true)
+          .usePhotonVisionLocation(false)
           .maxRotationsPerSecond(DEFAULT_MAX_ROTATIONS_PER_SECOND)
           .maxVelocityInMetersPerSecond(DEFAULT_MAX_VELOCITY_METERS_PER_SECOND)
           .maxLimelightDifferenceMeters(1.0);
@@ -139,6 +140,8 @@ public class Drive extends SubsystemBase implements AutoCloseable {
     @AutoBuilder
     public interface Builder {
       Builder addLimelightMeasurement(boolean enabled);
+
+      Builder usePhotonVisionLocation(boolean enabled);
 
       Builder maxRotationsPerSecond(DoubleSupplier value);
 
@@ -508,7 +511,7 @@ public class Drive extends SubsystemBase implements AutoCloseable {
     // Publish data to NetworkTables
     expectedState.set(drivetrain.getState().ModuleTargets);
     actualState.set(drivetrain.getState().ModuleStates);
-    if (AllPreferences.usePhotonVisionLocation().getAsBoolean()) {
+    if (config.usePhotonVisionLocation) {
       photonPoseEstimator.update(this::handlePhotonPose);
     }
     Pose2d pose = getPose();


### PR DESCRIPTION
This updates the preference to be retrieved the same way as the other
drive subsystem configuration, and ensures that the value will be
displayed alongside other drive configuration values in Elastic.

Changes:
- Remove `AllPreferences.usePhotonVisionLocation()`
- Add `usePhotonVisionLocation` to `DriveConfiguration`
- Migrate preferences stored on the robot from the old key to the new one
- Delete no-longer references preference keys from the robot

Tested in the simulator.