### PR TITLE
TimestampedStructPublisher.publish() now takes in a simpler value object

### DIFF
--- a/src/main/java/com/team2813/vision/LimelightPosePublisher.java
+++ b/src/main/java/com/team2813/vision/LimelightPosePublisher.java
@@ -5,14 +5,13 @@ import com.team2813.lib2813.limelight.BotPoseEstimate;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.StructTopic;
-import edu.wpi.first.networktables.TimestampedObject;
+import edu.wpi.first.units.Units;
 import edu.wpi.first.wpilibj.Timer;
 import java.util.Optional;
 import java.util.function.Supplier;
 
 public final class LimelightPosePublisher {
   public static final String TABLE_NAME = "limelight";
-  private static final long MICROS_PER_SECOND = 1_000_000;
   private final TimestampedStructPublisher<Pose2d> publisher;
   private final double timestampOffset;
 
@@ -34,16 +33,12 @@ public final class LimelightPosePublisher {
    * @param poseEstimate The estimated location (with the blue driver station as the origin).
    */
   public void publish(Optional<BotPoseEstimate> poseEstimate) {
-    publisher.publish(poseEstimate.stream().map(this::toTimestampedObject).toList());
+    publisher.publish(poseEstimate.stream().map(this::toTimestampedValue).toList());
   }
 
-  private TimestampedObject<Pose2d> toTimestampedObject(BotPoseEstimate estimate) {
-    return new TimestampedObject<>(timestampMicros(estimate), 0, estimate.pose());
-  }
-
-  private long timestampMicros(BotPoseEstimate estimate) {
-    double fpgaTimestampSeconds = currentTimeToFpgaTime(estimate.timestampSeconds());
-    return (long) (fpgaTimestampSeconds * MICROS_PER_SECOND);
+  private TimestampedValue<Pose2d> toTimestampedValue(BotPoseEstimate estimate) {
+    return TimestampedValue.withFpgaTimestamp(
+        currentTimeToFpgaTime(estimate.timestampSeconds()), Units.Seconds, estimate.pose());
   }
 
   /**

--- a/src/main/java/com/team2813/vision/PhotonVisionPosePublisher.java
+++ b/src/main/java/com/team2813/vision/PhotonVisionPosePublisher.java
@@ -2,7 +2,7 @@ package com.team2813.vision;
 
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.networktables.StructTopic;
-import edu.wpi.first.networktables.TimestampedObject;
+import edu.wpi.first.units.Units;
 import edu.wpi.first.wpilibj.Timer;
 import java.util.List;
 import java.util.function.Supplier;
@@ -10,7 +10,6 @@ import org.photonvision.EstimatedRobotPose;
 import org.photonvision.PhotonCamera;
 
 public final class PhotonVisionPosePublisher {
-  private static final long MICROS_PER_SECOND = 1_000_000;
   private final TimestampedStructPublisher<Pose3d> publisher;
 
   public PhotonVisionPosePublisher(PhotonCamera camera) {
@@ -30,11 +29,11 @@ public final class PhotonVisionPosePublisher {
    */
   public void publish(List<EstimatedRobotPose> poseEstimates) {
     publisher.publish(
-        poseEstimates.stream().map(PhotonVisionPosePublisher::toTimestampedObject).toList());
+        poseEstimates.stream().map(PhotonVisionPosePublisher::toTimestampedValue).toList());
   }
 
-  private static TimestampedObject<Pose3d> toTimestampedObject(EstimatedRobotPose pose) {
-    return new TimestampedObject<>(
-        (long) (pose.timestampSeconds * MICROS_PER_SECOND), 0, pose.estimatedPose);
+  private static TimestampedValue<Pose3d> toTimestampedValue(EstimatedRobotPose pose) {
+    return TimestampedValue.withFpgaTimestamp(
+        pose.timestampSeconds, Units.Seconds, pose.estimatedPose);
   }
 }

--- a/src/main/java/com/team2813/vision/TimestampedStructPublisher.java
+++ b/src/main/java/com/team2813/vision/TimestampedStructPublisher.java
@@ -2,7 +2,6 @@ package com.team2813.vision;
 
 import edu.wpi.first.networktables.StructPublisher;
 import edu.wpi.first.networktables.StructTopic;
-import edu.wpi.first.networktables.TimestampedObject;
 import edu.wpi.first.wpilibj.TimedRobot;
 import java.util.List;
 import java.util.function.Supplier;
@@ -36,13 +35,9 @@ final class TimestampedStructPublisher<S> {
     publishedZeroValue = true;
   }
 
-  /**
-   * Publishes the values to network tables.
-   *
-   * @param values Timestamped data, with the timestamps in FPGA millis.
-   */
-  public void publish(List<TimestampedObject<S>> values) {
-    if (values.isEmpty()) {
+  /** Publishes the values to network tables. */
+  public void publish(List<TimestampedValue<S>> timestampedValues) {
+    if (timestampedValues.isEmpty()) {
       if (!publishedZeroValue) {
         long currentTimeMicros = currentTimeMicros();
         long microsSinceLastUpdate = currentTimeMicros - lastUpdateTimeMicros;
@@ -53,10 +48,10 @@ final class TimestampedStructPublisher<S> {
         }
       }
     } else {
-      for (TimestampedObject<S> object : values) {
-        long timestampMicros = object.timestamp;
+      for (var timestampedValue : timestampedValues) {
+        long timestampMicros = timestampedValue.networkTablesTimestampMicros();
         lastUpdateTimeMicros = Math.max(lastUpdateTimeMicros, timestampMicros);
-        publisher.set(object.value, timestampMicros);
+        publisher.set(timestampedValue.value(), timestampMicros);
       }
       publishedZeroValue = false;
     }

--- a/src/main/java/com/team2813/vision/TimestampedValue.java
+++ b/src/main/java/com/team2813/vision/TimestampedValue.java
@@ -1,0 +1,81 @@
+package com.team2813.vision;
+
+import edu.wpi.first.networktables.StructSubscriber;
+import edu.wpi.first.networktables.TimestampedObject;
+import edu.wpi.first.units.TimeUnit;
+import edu.wpi.first.units.Units;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Holder for a value to publish to network tables with a provided timestamp.
+ *
+ * @param <T> type of the value to publish.
+ */
+public final class TimestampedValue<T> {
+  private final long networkTablesTimestamp;
+  private final T value;
+
+  public static <T> TimestampedValue<T> withFpgaTimestamp(
+      double fpgaTimestamp, TimeUnit timeUnit, T value) {
+    return withFpgaTimestampMicros(
+        (long) Units.Microseconds.convertFrom(fpgaTimestamp, timeUnit), value);
+  }
+
+  public static <T> TimestampedValue<T> withFpgaTimestampMicros(long fpgaTimestamp, T value) {
+    return new TimestampedValue<>(fpgaTimestamp, value);
+  }
+
+  public static <T> TimestampedValue<T> fromTimestampedObject(
+      TimestampedObject<T> timestampedObject) {
+    return withFpgaTimestampMicros(timestampedObject.timestamp, timestampedObject.value);
+  }
+
+  private TimestampedValue(long fpgaTimestamp, T value) {
+    this.networkTablesTimestamp = fpgaTimestamp;
+    this.value = Objects.requireNonNull(value);
+  }
+
+  static <T> List<TimestampedValue<T>> fromSubscriberQueue(StructSubscriber<T> subscriber) {
+    return Arrays.stream(subscriber.readQueue())
+        .map(TimestampedValue::fromTimestampedObject)
+        .toList();
+  }
+
+  /**
+   * Gets the network tables timestamp value for this instance.
+   *
+   * @return the FPGA timestamp in milliseconds
+   */
+  public long networkTablesTimestampMicros() {
+    // Note: Per the WPILib documentation at
+    // https://docs.wpilib.org/en/stable/docs/software/networktables/networktables-intro.html#timestamps
+    // timestamps in NetworkTables are measured in integer microseconds. When the RoboRIO is the
+    // NetworkTables server, the server timestamp is the same as the FPGA timestamp returned by
+    // Timer.getFPGATimestamp() (except the units are different: NetworkTables uses microseconds,
+    // while getFPGATimestamp() returns seconds).
+    return networkTablesTimestamp;
+  }
+
+  public T value() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other instanceof TimestampedValue<?> that) {
+      return networkTablesTimestamp == that.networkTablesTimestamp && value.equals(that.value);
+    }
+
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(networkTablesTimestamp, value);
+  }
+}

--- a/src/main/java/com/team2813/vision/TimestampedValue.java
+++ b/src/main/java/com/team2813/vision/TimestampedValue.java
@@ -13,7 +13,7 @@ import java.util.Objects;
  *
  * @param <T> type of the value to publish.
  */
-public final class TimestampedValue<T> {
+final class TimestampedValue<T> {
   private final long networkTablesTimestamp;
   private final T value;
 

--- a/src/test/java/com/team2813/vision/PhotonVisionPosePublisherTest.java
+++ b/src/test/java/com/team2813/vision/PhotonVisionPosePublisherTest.java
@@ -102,6 +102,7 @@ public class PhotonVisionPosePublisherTest {
   }
 
   private static class FakeClock implements Supplier<Double> {
+    @Override
     public Double get() {
       return 2.0;
     }


### PR DESCRIPTION
Previously it took in a `List<TimestampedObject<>>` and ignored the `serverTime`
argument.

This resolves code review comments raised in #118

Changes:
- Create `TimestampedValue<>` (extracted from `TimestampedStructPublisherTest`)
- Add `@Override` to methods implementing interface methods 