### PR TITLE
Migrate USE_AUTO_ALIGN_WAYPOINTS preference to PersistedConfiguration

### DIFF
--- a/src/main/java/com/team2813/AllPreferences.java
+++ b/src/main/java/com/team2813/AllPreferences.java
@@ -17,7 +17,7 @@ class AllPreferences {
   private static final Map<Key, String> LEGACY_BOOLEAN_PREFERENCES =
       Map.of(
           Key.USE_AUTO_ALIGN_WAYPOINTS,
-          "commands.RobotLocalization.AutoAlignConfiguration.useAutoAlignWaypoints",
+          "RobotLocalization/useAutoAlignWaypoints",
           Key.USE_PHOTON_VISION_LOCATION,
           "subsystems.Drive.DriveConfiguration.usePhotonVisionLocation");
 

--- a/src/main/java/com/team2813/AllPreferences.java
+++ b/src/main/java/com/team2813/AllPreferences.java
@@ -3,17 +3,21 @@ package com.team2813;
 import edu.wpi.first.wpilibj.Preferences;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BooleanSupplier;
 
 /**
  * Holder for all values stored in {@link Preferences} for the robot.
  *
  * <p>The values can be viewed and edited on SmartDashboard or Shuffleboard. If the values are
  * edited, the updated values are persisted across reboots.
+ *
+ * @deprecated use {@link com.team2813.lib2813.preferences.PreferencesInjector}
  */
-public class AllPreferences {
+@Deprecated
+class AllPreferences {
   private static final Map<Key, String> LEGACY_BOOLEAN_PREFERENCES =
       Map.of(
+          Key.USE_AUTO_ALIGN_WAYPOINTS,
+          "commands.RobotLocalization.AutoAlignConfiguration.useAutoAlignWaypoints",
           Key.USE_PHOTON_VISION_LOCATION,
           "subsystems.Drive.DriveConfiguration.usePhotonVisionLocation");
 
@@ -37,18 +41,6 @@ public class AllPreferences {
         Preferences.remove(key);
       }
     }
-  }
-
-  public static BooleanSupplier useAutoAlignWaypoints() {
-    return booleanPref(Key.USE_AUTO_ALIGN_WAYPOINTS, true);
-  }
-
-  private static BooleanSupplier booleanPref(Key key, boolean defaultValue) {
-    String name = key.name();
-    if (!Preferences.containsKey(name)) {
-      Preferences.initBoolean(name, defaultValue);
-    }
-    return () -> Preferences.getBoolean(name, defaultValue);
   }
 
   private enum Key {

--- a/src/main/java/com/team2813/RobotContainer.java
+++ b/src/main/java/com/team2813/RobotContainer.java
@@ -51,7 +51,7 @@ public class RobotContainer implements AutoCloseable {
   private final SysIdRoutineSelector sysIdRoutineSelector;
 
   public RobotContainer(ShuffleboardTabs shuffleboard, NetworkTableInstance networkTableInstance) {
-    var localization = new RobotLocalization();
+    var localization = new RobotLocalization(networkTableInstance);
     this.drive = new Drive(networkTableInstance, localization);
     this.elevator = new Elevator(networkTableInstance);
     this.intakePivot = new IntakePivot(networkTableInstance);

--- a/src/main/java/com/team2813/commands/RobotLocalization.java
+++ b/src/main/java/com/team2813/commands/RobotLocalization.java
@@ -50,7 +50,7 @@ public class RobotLocalization {
     }
 
     @com.google.auto.value.AutoBuilder
-    interface Builder {
+    public interface Builder {
       Builder useAutoAlignWaypoints(boolean enabled);
 
       AutoAlignConfiguration build();

--- a/src/main/java/com/team2813/commands/RobotLocalization.java
+++ b/src/main/java/com/team2813/commands/RobotLocalization.java
@@ -9,7 +9,7 @@ import com.team2813.RobotContainer;
 import com.team2813.lib2813.limelight.BotPoseEstimate;
 import com.team2813.lib2813.limelight.Limelight;
 import com.team2813.lib2813.limelight.LocationalData;
-import com.team2813.lib2813.preferences.PreferencesInjector;
+import com.team2813.lib2813.preferences.PersistedConfiguration;
 import com.team2813.subsystems.Drive;
 import com.team2813.vision.LimelightPosePublisher;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -29,39 +29,26 @@ import org.json.simple.parser.ParseException;
 public class RobotLocalization {
   private static final Pose3d[] EMPTY_POSE3D_ARRAY = new Pose3d[0];
   private static final Limelight limelight = Limelight.getDefaultLimelight();
-  private final AutoAlignConfiguration config;
+  private final Configuration config;
   private final StructPublisher<Pose2d> lastPosePublisher;
   private final LimelightPosePublisher limelightPosePublisher;
   private final BooleanPublisher hasDataPublisher;
   private final StructArrayPublisher<Pose3d> visibleAprilTagPosesPublisher;
 
-  public record AutoAlignConfiguration(boolean useAutoAlignWaypoints) {
-
-    /** Creates a builder for {@code AutoAlignConfiguration} with default values. */
-    public static AutoAlignConfiguration.Builder builder() {
-      return new AutoBuilder_RobotLocalization_AutoAlignConfiguration_Builder()
-          .useAutoAlignWaypoints(true);
-    }
+  /** Holder for all configuration for {@link RobotLocalization}. */
+  public record Configuration(boolean useAutoAlignWaypoints) {
 
     /** Creates an instance from preference values stored in the robot's flash memory. */
-    public static AutoAlignConfiguration fromPreferences() {
-      AutoAlignConfiguration defaultConfig = builder().build();
-      return PreferencesInjector.DEFAULT_INSTANCE.injectPreferences(defaultConfig);
-    }
-
-    @com.google.auto.value.AutoBuilder
-    public interface Builder {
-      Builder useAutoAlignWaypoints(boolean enabled);
-
-      AutoAlignConfiguration build();
+    public static Configuration fromPreferences() {
+      return PersistedConfiguration.fromPreferences("RobotLocalization", Configuration.class);
     }
   }
 
   public RobotLocalization(NetworkTableInstance networkTableInstance) {
-    this(networkTableInstance, AutoAlignConfiguration.fromPreferences());
+    this(networkTableInstance, Configuration.fromPreferences());
   }
 
-  RobotLocalization(NetworkTableInstance networkTableInstance, AutoAlignConfiguration config) {
+  RobotLocalization(NetworkTableInstance networkTableInstance, Configuration config) {
     this.config = config;
 
     lastPosePublisher =

--- a/src/main/java/com/team2813/commands/RobotLocalization.java
+++ b/src/main/java/com/team2813/commands/RobotLocalization.java
@@ -53,12 +53,20 @@ public class RobotLocalization {
     }
   }
 
-  public RobotLocalization() {
-    this(AutoAlignConfiguration.fromPreferences());
+  public RobotLocalization(NetworkTableInstance networkTableInstance) {
+    this(networkTableInstance, AutoAlignConfiguration.fromPreferences());
   }
 
-  RobotLocalization(AutoAlignConfiguration config) {
+  RobotLocalization(NetworkTableInstance networkTableInstance, AutoAlignConfiguration config) {
     this.config = config;
+
+    lastPosePublisher =
+        networkTableInstance.getStructTopic("Auto Align to", Pose2d.struct).publish();
+    limelightPosePublisher = new LimelightPosePublisher(networkTableInstance);
+    hasDataPublisher =
+        LimelightPosePublisher.getNetworkTable(networkTableInstance)
+            .getBooleanTopic("hasData")
+            .publish();
   }
 
   public Optional<BotPoseEstimate> limelightLocation(
@@ -132,8 +140,7 @@ public class RobotLocalization {
     return arrayOfPos;
   }
 
-  private final StructPublisher<Pose2d> lastPosePublisher =
-      NetworkTableInstance.getDefault().getStructTopic("Auto Align to", Pose2d.struct).publish();
+  private final StructPublisher<Pose2d> lastPosePublisher;
 
   /**
    * Creates a command from the current position to the nearest target.
@@ -207,12 +214,8 @@ public class RobotLocalization {
     return AutoBuilder.pathfindThenFollowPath(path, constraints);
   }
 
-  private final LimelightPosePublisher limelightPosePublisher =
-      new LimelightPosePublisher(NetworkTableInstance.getDefault());
-  private final BooleanPublisher hasDataPublisher =
-      LimelightPosePublisher.getNetworkTable(NetworkTableInstance.getDefault())
-          .getBooleanTopic("hasData")
-          .publish();
+  private final LimelightPosePublisher limelightPosePublisher;
+  private final BooleanPublisher hasDataPublisher;
   private final StructArrayPublisher<Pose3d> visibleAprilTagPosesPublisher =
       LimelightPosePublisher.getNetworkTable(NetworkTableInstance.getDefault())
           .getStructArrayTopic("visibleAprilTagPoses", Pose3d.struct)


### PR DESCRIPTION
This updates the preference to use the most recent preference code.

Changes:
- Update lib2813 to the include https://github.com/Prospect-Robotics/lib2813/pull/38
- Remove `AllPreferences.useAutoAlignWaypoints()`
- Deprecate `AllPreferences`
- Add `Configuration` record class (nested in `RobotLocalization`) 
- Update `RobotLocalization` constructors to take in a `NetworkTablesInstance`
- Move field declarations to the top of `RobotLocalization.java`

Tested in the simulator.