### PR TITLE
Publish visible target poses to network tables

### DIFF
--- a/AdvantageScope-simulator.json
+++ b/AdvantageScope-simulator.json
@@ -12,9 +12,9 @@
             "/Drive",
             "/photonvision/capt-barnacles",
             "/photonvision/professor-inkling",
-            "/Vision",
             "/Vision/capt-barnacles",
-            "/Vision/professor-inkling"
+            "/Vision/professor-inkling",
+            "/Vision/limelight"
           ]
         },
         "tabs": {
@@ -61,7 +61,7 @@
                     "type": "ghost",
                     "logKey": "NT:/Drive/simulated pose",
                     "logType": "Pose2d",
-                    "visible": true,
+                    "visible": false,
                     "options": {
                       "color": "#00ffff"
                     }
@@ -75,21 +75,31 @@
                   },
                   {
                     "type": "vision",
-                    "logKey": "NT:/photonvision/capt-barnacles/targetPose",
-                    "logType": "Transform3d",
+                    "logKey": "NT:/Vision/capt-barnacles/aprilTagPose",
+                    "logType": "Pose3d",
                     "visible": true,
                     "options": {
-                      "color": "#0000ff",
+                      "color": "#00ffff",
                       "size": "normal"
                     }
                   },
                   {
                     "type": "vision",
-                    "logKey": "NT:/photonvision/professor-inkling/targetPose",
-                    "logType": "Transform3d",
+                    "logKey": "NT:/Vision/professor-inkling/aprilTagPose",
+                    "logType": "Pose3d",
                     "visible": true,
                     "options": {
                       "color": "#ff8c00",
+                      "size": "normal"
+                    }
+                  },
+                  {
+                    "type": "vision",
+                    "logKey": "NT:/Vision/limelight/visibleAprilTagPoses",
+                    "logType": "Pose3d[]",
+                    "visible": false,
+                    "options": {
+                      "color": "#00ff00",
                       "size": "normal"
                     }
                   },
@@ -108,7 +118,16 @@
                     "logType": "Pose3d",
                     "visible": true,
                     "options": {
-                      "color": "#0000ff"
+                      "color": "#00ffff"
+                    }
+                  },
+                  {
+                    "type": "ghost",
+                    "logKey": "NT:/Vision/limelight/poseEstimate",
+                    "logType": "Pose2d",
+                    "visible": true,
+                    "options": {
+                      "color": "#00ff00"
                     }
                   }
                 ],

--- a/src/main/java/com/team2813/subsystems/Drive.java
+++ b/src/main/java/com/team2813/subsystems/Drive.java
@@ -527,8 +527,6 @@ public class Drive extends SubsystemBase implements AutoCloseable {
     visibleTargetPoses.accept(visibleAprilTagPoses.toArray(EMPTY_LIST));
 
     modulePositions.accept(IntStream.range(0, 4).mapToDouble(this::getPosition).toArray());
-
-    localization.updateDashboard();
   }
 
   @Override

--- a/src/main/java/com/team2813/vision/MultiPhotonPoseEstimator.java
+++ b/src/main/java/com/team2813/vision/MultiPhotonPoseEstimator.java
@@ -92,7 +92,7 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
       PhotonPoseEstimator estimator =
           new PhotonPoseEstimator(
               builder.fieldTags, builder.poseStrategy, cameraConfig.robotToCamera);
-      var estimatedPosePublisher = new PhotonVisionPosePublisher(camera);
+      var estimatedPosePublisher = new PhotonVisionPosePublisher(camera, builder.fieldTags);
       NetworkTable table = getTableForCamera(camera);
       var cameraPosePublisher = table.getStructTopic("cameraPose", Pose3d.struct).publish();
 

--- a/src/main/java/com/team2813/vision/PhotonVisionPosePublisher.java
+++ b/src/main/java/com/team2813/vision/PhotonVisionPosePublisher.java
@@ -2,6 +2,7 @@ package com.team2813.vision;
 
 import static com.team2813.vision.VisionUtil.getTableForCamera;
 
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.StructTopic;
@@ -9,20 +10,27 @@ import edu.wpi.first.units.Units;
 import edu.wpi.first.wpilibj.Timer;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import org.photonvision.EstimatedRobotPose;
 import org.photonvision.PhotonCamera;
 
 public final class PhotonVisionPosePublisher {
   private final TimestampedStructPublisher<Pose3d> publisher;
+  private final TimestampedStructPublisher<Pose3d> tagPublisher;
+  private final AprilTagFieldLayout fieldTags;
 
-  public PhotonVisionPosePublisher(PhotonCamera camera) {
-    this(camera, Timer::getFPGATimestamp);
+  public PhotonVisionPosePublisher(PhotonCamera camera, AprilTagFieldLayout fieldTags) {
+    this(camera, fieldTags, Timer::getFPGATimestamp);
   }
 
-  PhotonVisionPosePublisher(PhotonCamera camera, Supplier<Double> fpgaTimestampSupplier) {
+  PhotonVisionPosePublisher(
+      PhotonCamera camera, AprilTagFieldLayout fieldTags, Supplier<Double> fpgaTimestampSupplier) {
+    this.fieldTags = fieldTags;
     NetworkTable table = getTableForCamera(camera);
     StructTopic<Pose3d> topic = table.getStructTopic("poseEstimate", Pose3d.struct);
     publisher = new TimestampedStructPublisher<>(topic, Pose3d.kZero, fpgaTimestampSupplier);
+    topic = table.getStructTopic("aprilTagPose", Pose3d.struct);
+    tagPublisher = new TimestampedStructPublisher<>(topic, Pose3d.kZero, fpgaTimestampSupplier);
   }
 
   /**
@@ -32,11 +40,27 @@ public final class PhotonVisionPosePublisher {
    */
   public void publish(List<EstimatedRobotPose> poseEstimates) {
     publisher.publish(
-        poseEstimates.stream().map(PhotonVisionPosePublisher::toTimestampedValue).toList());
+        poseEstimates.stream()
+            .map(PhotonVisionPosePublisher::toRobotPoseTimestampedValue)
+            .toList());
+    tagPublisher.publish(
+        poseEstimates.stream().flatMap(this::toAprilTagPoseTimestampedValue).toList());
   }
 
-  private static TimestampedValue<Pose3d> toTimestampedValue(EstimatedRobotPose pose) {
+  private static TimestampedValue<Pose3d> toRobotPoseTimestampedValue(EstimatedRobotPose pose) {
     return TimestampedValue.withFpgaTimestamp(
         pose.timestampSeconds, Units.Seconds, pose.estimatedPose);
+  }
+
+  private Stream<TimestampedValue<Pose3d>> toAprilTagPoseTimestampedValue(EstimatedRobotPose pose) {
+    if (pose.targetsUsed.isEmpty()) {
+      return Stream.empty();
+    }
+    return fieldTags
+        .getTagPose(pose.targetsUsed.get(0).fiducialId)
+        .map(
+            tagPose ->
+                TimestampedValue.withFpgaTimestamp(pose.timestampSeconds, Units.Seconds, tagPose))
+        .stream();
   }
 }

--- a/src/test/java/com/team2813/vision/PhotonVisionPosePublisherTest.java
+++ b/src/test/java/com/team2813/vision/PhotonVisionPosePublisherTest.java
@@ -3,6 +3,8 @@ package com.team2813.vision;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.team2813.NetworkTableResource;
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.networktables.*;
@@ -110,7 +112,9 @@ public class PhotonVisionPosePublisherTest {
 
   protected PhotonVisionPosePublisher createPublisher() {
     var camera = new PhotonCamera(networkTable.getNetworkTableInstance(), CAMERA_NAME);
-    return new PhotonVisionPosePublisher(camera, fakeClock);
+    AprilTagFieldLayout fieldTags =
+        AprilTagFieldLayout.loadField(AprilTagFields.k2025ReefscapeWelded);
+    return new PhotonVisionPosePublisher(camera, fieldTags, fakeClock);
   }
 
   private record TimestampedPose(Pose3d pose, long timestamp) {


### PR DESCRIPTION
This will allow us to diagnose why we sometimes get estimated pose
values that are quite far off (see, for example, Galileo Q21 where
`/Vision/capt-barnacles/poseEstimate` jumps around at the end of
the autonomous period).

Tested in the simulator.