### PR TITLE
Add logging for build constants

### DIFF
--- a/src/main/java/com/team2813/BuildConstantsPublisher.java
+++ b/src/main/java/com/team2813/BuildConstantsPublisher.java
@@ -97,4 +97,16 @@ public class BuildConstantsPublisher {
     m_buildUnixTimePublisher.set(BuildConstants.BUILD_UNIX_TIME);
     m_dirtyPublisher.set(BuildConstants.DIRTY);
   }
+
+  /** Logs build constants to the console. */
+  public void log() {
+    System.out.println("MavenName:     " + BuildConstants.MAVEN_NAME);
+    System.out.println("GitRevision:   " + BuildConstants.GIT_REVISION);
+    System.out.println("GitSha:        " + BuildConstants.GIT_SHA);
+    System.out.println("GitDate:       " + BuildConstants.GIT_DATE);
+    System.out.println("GitBranch:     " + BuildConstants.GIT_BRANCH);
+    System.out.println("BuildDate:     " + BuildConstants.BUILD_DATE);
+    System.out.println("BuildUnixTime: " + BuildConstants.BUILD_UNIX_TIME);
+    System.out.println("Dirty:         " + BuildConstants.DIRTY);
+  }
 }

--- a/src/main/java/com/team2813/Robot.java
+++ b/src/main/java/com/team2813/Robot.java
@@ -31,11 +31,9 @@ public class Robot extends TimedRobot {
   @Override
   public void robotInit() {
     SignalLogger.setPath("/U/logs");
-    // Use the default log directory for simulation because `/U/...` is typically not a valid root
-    // on
-    // the simulation host machine (usually, a Windows laptop).
+    // Use the default log directory ("") for simulation because "/U/..." is typically not a valid
+    // root on the simulation host machine (usually, a Windows laptop).
     DataLogManager.start(isSimulation() ? "" : "/U/logs");
-    System.out.println("DataLogManager.getLogDir: " + DataLogManager.getLogDir());
     DataLogManager.logNetworkTables(true);
     DriverStation.startDataLog(DataLogManager.getLog());
     SignalLogger.enableAutoLogging(true);

--- a/src/main/java/com/team2813/Robot.java
+++ b/src/main/java/com/team2813/Robot.java
@@ -31,7 +31,11 @@ public class Robot extends TimedRobot {
   @Override
   public void robotInit() {
     SignalLogger.setPath("/U/logs");
-    DataLogManager.start("/U/logs");
+    // Use the default log directory for simulation because `/U/...` is typically not a valid root
+    // on
+    // the simulation host machine (usually, a Windows laptop).
+    DataLogManager.start(isSimulation() ? "" : "/U/logs");
+    System.out.println("DataLogManager.getLogDir: " + DataLogManager.getLogDir());
     DataLogManager.logNetworkTables(true);
     DriverStation.startDataLog(DataLogManager.getLog());
     SignalLogger.enableAutoLogging(true);
@@ -40,8 +44,9 @@ public class Robot extends TimedRobot {
       SignalLogger.start();
     }
     CameraServer.startAutomaticCapture();
-    // Publish build constants to NetworkTables.
+    // Publish build constants to the Metadata table on NetworkTables.
     m_buildConstantsPublisher.publish();
+    m_buildConstantsPublisher.log();
   }
 
   @Override

--- a/src/main/java/com/team2813/Robot.java
+++ b/src/main/java/com/team2813/Robot.java
@@ -31,9 +31,7 @@ public class Robot extends TimedRobot {
   @Override
   public void robotInit() {
     SignalLogger.setPath("/U/logs");
-    // Use the default log directory ("") for simulation because "/U/..." is typically not a valid
-    // root on the simulation host machine (usually, a Windows laptop).
-    DataLogManager.start(isSimulation() ? "" : "/U/logs");
+    DataLogManager.start("/U/logs");
     DataLogManager.logNetworkTables(true);
     DriverStation.startDataLog(DataLogManager.getLog());
     SignalLogger.enableAutoLogging(true);

--- a/src/main/java/com/team2813/Robot.java
+++ b/src/main/java/com/team2813/Robot.java
@@ -40,7 +40,7 @@ public class Robot extends TimedRobot {
       SignalLogger.start();
     }
     CameraServer.startAutomaticCapture();
-    // Publish build constants to the Metadata table on NetworkTables.
+    // Publish build constants to the Metadata table on NetworkTables and print them in system log.
     m_buildConstantsPublisher.publish();
     m_buildConstantsPublisher.log();
   }

--- a/src/test/java/com/team2813/BuildConstantsPublisherTest.java
+++ b/src/test/java/com/team2813/BuildConstantsPublisherTest.java
@@ -5,19 +5,16 @@ import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.truth.FailureMetadata;
+import com.google.common.truth.Subject;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-
 import org.junit.Test;
-
-import com.google.common.truth.FailureMetadata;
-import com.google.common.truth.Subject;
-
-import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.networktables.NetworkTableInstance;
 
 public class BuildConstantsPublisherTest {
 

--- a/src/test/java/com/team2813/BuildConstantsPublisherTest.java
+++ b/src/test/java/com/team2813/BuildConstantsPublisherTest.java
@@ -126,7 +126,6 @@ public class BuildConstantsPublisherTest {
 
     // Assert.
     try {
-
       assertThat(outputStream.toString())
           .containsMatch(
               // NOTE that \r?\n is used to match both Windows (\r\n) and Unix (\n) line endings.

--- a/src/test/java/com/team2813/BuildConstantsPublisherTest.java
+++ b/src/test/java/com/team2813/BuildConstantsPublisherTest.java
@@ -5,16 +5,19 @@ import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.truth.FailureMetadata;
-import com.google.common.truth.Subject;
-import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.networktables.NetworkTableInstance;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+
 import org.junit.Test;
+
+import com.google.common.truth.FailureMetadata;
+import com.google.common.truth.Subject;
+
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
 
 public class BuildConstantsPublisherTest {
 
@@ -122,26 +125,30 @@ public class BuildConstantsPublisherTest {
     publisher.log();
 
     // Assert.
-    assertThat(outputStream.toString())
-        .containsMatch(
-            // NOTE that [\r\n]+ is used to match both Windows (\r\n) and Unix (\n) line endings.
-            "MavenName:     Robot2025[\r\n]+"
-                // Matches a Git revision number, e.g., "121"
-                + "GitRevision:   [0-9]+[\r\n]+"
-                // Matches a Git revision hash, e.g., 08205a25fe10c6c6c1ea4db2deabb4aaf4617637
-                + "GitSha:        [0-9a-f]+[\r\n]+"
-                // Matches a Git date, e.g., "2023-10-01 12:34:56 PDT"
-                + "GitDate:       \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.+[\r\n]+"
-                // Matches a Git branch name, e.g., "main"
-                + "GitBranch:     .+[\r\n]+"
-                // Matches a build date, e.g., "2023-10-01 12:34:56 PDT"
-                + "BuildDate:     \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.+[\r\n]+"
-                // Matches a Unix timestamp, e.g., "1696175696"
-                + "BuildUnixTime: \\d+[\r\n]+"
-                // Matches a dirty flag, e.g., "0" or "1"
-                + "Dirty:         [01][\r\n]+");
+    try {
 
-    // Restore System.out
-    System.setOut(originalOut);
+      assertThat(outputStream.toString())
+          .containsMatch(
+              // NOTE that \r?\n is used to match both Windows (\r\n) and Unix (\n) line endings.
+              "MavenName:     Robot2025\r?\n"
+                  // Matches a Git revision number, e.g., "121"
+                  + "GitRevision:   [0-9]+\r?\n"
+                  // Matches a Git revision hash, e.g., "08205a25fe10c6c6c1ea4db2deabb4aaf4617637"
+                  // Accepts "NA" for users that have no git installed.
+                  + "GitSha:        (NA|[0-9a-f]{40})\r?\n"
+                  // Matches a Git date, e.g., "2023-10-01 12:34:56 PDT"
+                  + "GitDate:       \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.+\r?\n"
+                  // Matches a Git branch name, e.g., "main"
+                  + "GitBranch:     .+\r?\n"
+                  // Matches a build date, e.g., "2023-10-01 12:34:56 PDT"
+                  + "BuildDate:     \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.+\r?\n"
+                  // Matches a Unix timestamp, e.g., "1696175696"
+                  + "BuildUnixTime: \\d+\r?\n"
+                  // Matches a dirty flag, e.g., "0" or "1"
+                  + "Dirty:         [01]\r?\n");
+    } finally {
+      // Restore System.out
+      System.setOut(originalOut);
+    }
   }
 }


### PR DESCRIPTION
In simulation mode, starting `DataLogManager` on `"/U/logs"` spams the console with warnings like these

```
DataLog: Log file deleted, recreating as fresh log 'wpilog_72b97e6cbc55439a.2.wpilog'
DataLog: Could not open log file '/U/logs\wpilog_72b97e6cbc55439a.2.wpilog': no such file or directory
DataLog: Could not open log file '/U/logs\wpilog_b9af36528ae34b0d.wpilog': no such file or directory
DataLog: Could not open log file '/U/logs\wpilog_2646392507786ccc.wpilog': no such file or directory
DataLog: Could not open log file '/U/logs\wpilog_b62cec7f92220530.wpilog': no such file or directory
DataLog: Could not open log file '/U/logs\wpilog_9253796d7790c555.wpilog': no such file or directory
DataLog: Could not open log file, no log being saved
```

When left to default (`""`), in simulation mode it starts logging under a suitable directory in the host machine, e.g., 

```
DataLog: Logging to 'C:\Users\vesel\GearHeads\Season 2025\RobotProjects\Robot2025/logs\FRC_TBD_a20d5bbbc86f5c86.wpilog' (802.4 GiB free space)
```