### PR TITLE
Attempt to suppress 'Auto builder has already been configured. This i…

### DIFF
--- a/src/main/java/com/team2813/RobotContainer.java
+++ b/src/main/java/com/team2813/RobotContainer.java
@@ -249,31 +249,36 @@ public class RobotContainer implements AutoCloseable {
       // Or handle the error more gracefully
       throw new RuntimeException("Could not get config!", e);
     }
-    AutoBuilder.configure(
-        drive::getPose, // Robot pose supplier
-        drive
-            ::setPose, // Method to reset odometry (will be called if your auto has a starting pose)
-        drive::getRobotRelativeSpeeds, // ChassisSpeeds supplier. MUST BE ROBOT RELATIVE
-        drive::drive, // Method that will drive the robot given ROBOT RELATIVE ChassisSpeeds. Also
-        // optionally outputs individual module feedforwards
-        new PPHolonomicDriveController( // PPHolonomicController is the built in path following
-            // controller for holonomic drive trains
-            new PIDConstants(15, 0.0, 0), // Translation PID constants
-            new PIDConstants(
-                6.85, 0.0, 1.3) // Rotation PID constants //make lower but 5 doesnt work
-            ),
-        config, // The robot configuration
-        () -> {
-          // Boolean supplier that controls when the path will be mirrored for the red alliance
-          // This will flip the path being followed to the red side of the field.
-          // THE ORIGIN WILL REMAIN ON THE BLUE SIDE
-          return DriverStation.getAlliance()
-              .map(alliance -> alliance != ALLIANCE_USED_IN_PATHS)
-              .orElse(false);
-        },
-        drive // Reference to this subsystem to set requirements
-        );
-    configureAutoCommands(elevator, intakePivot, intake, groundIntake, groundIntakePivot);
+    if (!AutoBuilder.isConfigured()) {
+      AutoBuilder.configure(
+          drive::getPose, // Robot pose supplier
+          // Method to reset odometry (will be called if your auto has a starting pose)
+          drive::setPose,
+          // ChassisSpeeds supplier. MUST BE ROBOT RELATIVE
+          drive::getRobotRelativeSpeeds,
+          // Method that will drive the robot given ROBOT RELATIVE ChassisSpeeds. Also optionally
+          // outputs individual module feedforwards
+          drive::drive,
+          // PPHolonomicController is the built-in path following controller for holonomic drive
+          // trains
+          new PPHolonomicDriveController(
+              // Translation PID constants
+              new PIDConstants(15, 0.0, 0),
+              // Rotation PID constants make lower but 5 doesn't work
+              new PIDConstants(6.85, 0.0, 1.3)),
+          config, // The robot configuration
+          () -> {
+            // Boolean supplier that controls when the path will be mirrored for the red alliance
+            // This will flip the path being followed to the red side of the field.
+            // THE ORIGIN WILL REMAIN ON THE BLUE SIDE
+            return DriverStation.getAlliance()
+                .map(alliance -> alliance != ALLIANCE_USED_IN_PATHS)
+                .orElse(false);
+          },
+          drive // Reference to this subsystem to set requirements
+          );
+      configureAutoCommands(elevator, intakePivot, intake, groundIntake, groundIntakePivot);
+    }
     return AutoBuilder.buildAutoChooser();
   }
 


### PR DESCRIPTION
…s likely in error.' during testing and simulation

Various tests and the simulation mode produced an error from the pathplanner.AutoBuilder library that looks like this:

```
Error at com.pathplanner.lib.auto.AutoBuilder.configure(AutoBuilder.java:72): Auto builder has already been configured. This is likely in error.
        at com.pathplanner.lib.auto.AutoBuilder.configure(AutoBuilder.java:72)
        at com.pathplanner.lib.auto.AutoBuilder.configure(AutoBuilder.java:143)
        at com.team2813.RobotContainer.configureAuto(RobotContainer.java:252)
        at com.team2813.RobotContainer.<init>(RobotContainer.java:62)
        at com.team2813.NamedCommandTest.commandExists(NamedCommandTest.java:39)
```

This is because in tests and simulation we occasionally create more than one `RobotContainer` and each instance tries to call `AutoBuilder.configure(...)` but it must be called only once.

It looks like `AutoBuilder.configure` is just printing this obnoxious stack trace but handles this merely as a warning, since it then proceeds and reconfigures all its static state (here's a [copy of the code](https://github.com/mjansen4857/pathplanner/blob/8157052a9e825044dd810c03a76d5d4e8912c972/pathplannerlib/src/main/java/com/pathplanner/lib/auto/AutoBuilder.java#L73), ... so odd that many teams choose to import this code in their libs) 

This PR might not be worth merging.  Rather, I'd just want to understand if we have some options to rearrange the code and avoid this warning in a more principled way. 

