### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,6 +26,6 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v4
     - name: Run build with Gradle Wrapper
       run: ./gradlew build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,6 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
-        cache: gradle
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
     - name: Run build with Gradle Wrapper


### PR DESCRIPTION
Changes:
* Use [updated Gradle setup action](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md)
* Swap to use Gradle's caching instead of the `setup-java` gradle caching
  * Allows us to do more stuff, including
    * Saving `configuration-cache` data
      * Fails because of the task to generate the `BuildConstants.java` file :)
    * Encrypt the cache (not sure if we care about this)
  * caching is actually maintained by the same group that updates Gradle, so it is highly likely that it will be updated to perform better, and and continue working as intended.