### PR TITLE
Create JUnit Extension for getting an isolated network table instance

### DIFF
--- a/src/test/java/com/team2813/IsolatedNetworkTablesExtension.java
+++ b/src/test/java/com/team2813/IsolatedNetworkTablesExtension.java
@@ -1,0 +1,69 @@
+package com.team2813;
+
+import edu.wpi.first.networktables.NetworkTableInstance;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+/**
+ * JUnit Jupiter extension for providing an isolated NetworkTableInstance to tests.
+ *
+ * <p>Example use:
+ *
+ * <pre>{@code
+ * @ExtendWith(IsolatedNetworkTablesExtension.class)
+ * public final class IntakeTest {
+ *
+ *   @Test
+ *   public void intakeCoral(NetworkTableInstance ntInstance)  {
+ *     // Do something with ntInstance
+ *   }
+ * }
+ * }</pre>
+ */
+public final class IsolatedNetworkTablesExtension
+    implements Extension, AfterEachCallback, BeforeEachCallback, ParameterResolver {
+  private static final String NETWORK_TABLE_INSTANCE_KEY = "networkTableInstance";
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    getStore(context).put(NETWORK_TABLE_INSTANCE_KEY, NetworkTableInstance.create());
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) throws Exception {
+    var networkTableInstance =
+        getStore(context).get(NETWORK_TABLE_INSTANCE_KEY, NetworkTableInstance.class);
+    networkTableInstance.close();
+  }
+
+  @Override
+  public boolean supportsParameter(
+      ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    return NetworkTableInstance.class.equals(parameterContext.getParameter().getType());
+  }
+
+  @Override
+  public NetworkTableInstance resolveParameter(
+      ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    var networkTableInstance =
+        getStore(extensionContext).get(NETWORK_TABLE_INSTANCE_KEY, NetworkTableInstance.class);
+    if (networkTableInstance == null) {
+      throw new ParameterResolutionException(
+          "Could not resolve " + parameterContext.getParameter());
+    }
+    return networkTableInstance;
+  }
+
+  private Store getStore(ExtensionContext context) {
+    return context.getStore(Namespace.create(getClass(), context.getRequiredTestMethod()));
+  }
+}

--- a/src/test/java/com/team2813/subsystems/IntakeTest.java
+++ b/src/test/java/com/team2813/subsystems/IntakeTest.java
@@ -4,19 +4,17 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-import com.team2813.NetworkTableResource;
+import com.team2813.IsolatedNetworkTablesExtension;
 import com.team2813.lib2813.control.ControlMode;
 import com.team2813.lib2813.control.PIDMotor;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 
-@RunWith(JUnit4.class)
+@ExtendWith(IsolatedNetworkTablesExtension.class)
 public final class IntakeTest {
   final FakePIDMotor fakeMotor = mock(FakePIDMotor.class, Answers.CALLS_REAL_METHODS);
-  @Rule public final NetworkTableResource ntResource = new NetworkTableResource();
 
   abstract static class FakePIDMotor implements PIDMotor {
     double dutyCycle = 0.0f;
@@ -29,23 +27,23 @@ public final class IntakeTest {
   }
 
   @Test
-  public void constructRealInstance() {
-    try (Intake intake = new Intake(ntResource.getNetworkTableInstance())) {
+  public void constructRealInstance(NetworkTableInstance ntInstance) {
+    try (Intake intake = new Intake(ntInstance)) {
       assertThat(intake.intaking()).isFalse();
     }
   }
 
   @Test
-  public void initialState() {
-    try (Intake intake = new Intake(fakeMotor, ntResource.getNetworkTableInstance())) {
+  public void initialState(NetworkTableInstance ntInstance) {
+    try (Intake intake = new Intake(fakeMotor, ntInstance)) {
       assertThat(intake.intaking()).isFalse();
       verifyNoInteractions(fakeMotor);
     }
   }
 
   @Test
-  public void intakeCoral() {
-    try (Intake intake = new Intake(fakeMotor, ntResource.getNetworkTableInstance())) {
+  public void intakeCoral(NetworkTableInstance ntInstance) {
+    try (Intake intake = new Intake(fakeMotor, ntInstance)) {
       intake.intakeCoral();
 
       assertThat(intake.intaking()).isTrue();
@@ -54,8 +52,8 @@ public final class IntakeTest {
   }
 
   @Test
-  public void stopAfterIntakingCoral() {
-    try (Intake intake = new Intake(fakeMotor, ntResource.getNetworkTableInstance())) {
+  public void stopAfterIntakingCoral(NetworkTableInstance ntInstance) {
+    try (Intake intake = new Intake(fakeMotor, ntInstance)) {
       intake.intakeCoral();
 
       intake.stopIntakeMotor();
@@ -66,8 +64,8 @@ public final class IntakeTest {
   }
 
   @Test
-  public void outtakeCoral() {
-    try (Intake intake = new Intake(fakeMotor, ntResource.getNetworkTableInstance())) {
+  public void outtakeCoral(NetworkTableInstance ntInstance) {
+    try (Intake intake = new Intake(fakeMotor, ntInstance)) {
       intake.outakeCoral();
 
       assertThat(intake.intaking()).isFalse();
@@ -76,8 +74,8 @@ public final class IntakeTest {
   }
 
   @Test
-  public void stopAfterOutakingCoral() {
-    try (Intake intake = new Intake(fakeMotor, ntResource.getNetworkTableInstance())) {
+  public void stopAfterOutakingCoral(NetworkTableInstance ntInstance) {
+    try (Intake intake = new Intake(fakeMotor, ntInstance)) {
       intake.outakeCoral();
 
       intake.stopIntakeMotor();
@@ -88,8 +86,8 @@ public final class IntakeTest {
   }
 
   @Test
-  public void bumpAlgae() {
-    try (Intake intake = new Intake(fakeMotor, ntResource.getNetworkTableInstance())) {
+  public void bumpAlgae(NetworkTableInstance ntInstance) {
+    try (Intake intake = new Intake(fakeMotor, ntInstance)) {
       intake.bumpAlgae();
 
       assertThat(intake.intaking()).isFalse();
@@ -98,8 +96,8 @@ public final class IntakeTest {
   }
 
   @Test
-  public void stopAfterBumpingAlgae() {
-    try (Intake intake = new Intake(fakeMotor, ntResource.getNetworkTableInstance())) {
+  public void stopAfterBumpingAlgae(NetworkTableInstance ntInstance) {
+    try (Intake intake = new Intake(fakeMotor, ntInstance)) {
       intake.bumpAlgae();
 
       intake.stopIntakeMotor();


### PR DESCRIPTION
This allows tests that use NetworkTableResource to migrate to JUnit Jupiter.