### PR TITLE
Fix autonomous routines

### DIFF
--- a/src/main/deploy/pathplanner/autos/left-0100.auto
+++ b/src/main/deploy/pathplanner/autos/left-0100.auto
@@ -17,7 +17,7 @@
               {
                 "type": "named",
                 "data": {
-                  "name": "ScoreL2"
+                  "name": "PrepareL2"
                 }
               }
             ]

--- a/src/main/deploy/pathplanner/autos/left-0200.auto
+++ b/src/main/deploy/pathplanner/autos/left-0200.auto
@@ -17,7 +17,7 @@
               {
                 "type": "named",
                 "data": {
-                  "name": "PrepareScore"
+                  "name": "PrepareL2"
                 }
               }
             ]

--- a/src/main/deploy/pathplanner/autos/left-0300.auto
+++ b/src/main/deploy/pathplanner/autos/left-0300.auto
@@ -17,7 +17,7 @@
               {
                 "type": "named",
                 "data": {
-                  "name": "PrepareScore"
+                  "name": "PrepareL2"
                 }
               }
             ]


### PR DESCRIPTION
* Make `left-0100` prepare to score instead of trying to score at start of auto
* Make `left-0200` and `left-0300` use `PrepareL2` instead of `PrepareScore`