### PR TITLE
 Variants of left-{0200,0300} autos with robot reversed at coral station

### DIFF
--- a/src/main/deploy/pathplanner/autos/left-0200-rev.auto
+++ b/src/main/deploy/pathplanner/autos/left-0200-rev.auto
@@ -1,0 +1,88 @@
+{
+  "version": "2025.0",
+  "command": {
+    "type": "sequential",
+    "data": {
+      "commands": [
+        {
+          "type": "parallel",
+          "data": {
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "left-lc2"
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "PrepareL2"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "ScoreL2"
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "lc2-top_coral-rev"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "IntakeCoral"
+          }
+        },
+        {
+          "type": "parallel",
+          "data": {
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "top_coral-lc4"
+                }
+              },
+              {
+                "type": "sequential",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "wait",
+                      "data": {
+                        "waitTime": 0.5
+                      }
+                    },
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "PrepareScore"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "ScoreL2"
+          }
+        }
+      ]
+    }
+  },
+  "resetOdom": true,
+  "folder": null,
+  "choreoAuto": false
+}

--- a/src/main/deploy/pathplanner/autos/left-0300-rev.auto
+++ b/src/main/deploy/pathplanner/autos/left-0300-rev.auto
@@ -1,0 +1,138 @@
+{
+  "version": "2025.0",
+  "command": {
+    "type": "sequential",
+    "data": {
+      "commands": [
+        {
+          "type": "parallel",
+          "data": {
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "left-lc2"
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "PrepareL2"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "ScoreL2"
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "lc2-top_coral-rev"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "IntakeCoral"
+          }
+        },
+        {
+          "type": "parallel",
+          "data": {
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "top_coral-lc4"
+                }
+              },
+              {
+                "type": "sequential",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "wait",
+                      "data": {
+                        "waitTime": 0.5
+                      }
+                    },
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "PrepareScore"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "ScoreL2"
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "lc4-top_coral-rev"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "IntakeCoral"
+          }
+        },
+        {
+          "type": "parallel",
+          "data": {
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "top_coral-rc4"
+                }
+              },
+              {
+                "type": "sequential",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "wait",
+                      "data": {
+                        "waitTime": 0.25
+                      }
+                    },
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "PrepareScore"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "ScoreL2"
+          }
+        }
+      ]
+    }
+  },
+  "resetOdom": true,
+  "folder": null,
+  "choreoAuto": false
+}

--- a/src/main/deploy/pathplanner/paths/lc2-top_coral-rev.path
+++ b/src/main/deploy/pathplanner/paths/lc2-top_coral-rev.path
@@ -1,0 +1,81 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 5.296712476344141,
+        "y": 5.091
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 4.94779223549488,
+        "y": 5.795235911086272
+      },
+      "isLocked": false,
+      "linkedName": "lc2"
+    },
+    {
+      "anchor": {
+        "x": 3.9964497120307167,
+        "y": 6.48388271917662
+      },
+      "prevControl": {
+        "x": 4.7213424682545,
+        "y": 6.214465492692572
+      },
+      "nextControl": {
+        "x": 3.271556955806933,
+        "y": 6.753299945660668
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 1.5428857751794762,
+        "y": 7.309
+      },
+      "prevControl": {
+        "x": 2.2125459950938566,
+        "y": 7.099685478909277
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "top_coral-rev"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [
+    {
+      "fieldPosition": {
+        "x": 4.073905999999999,
+        "y": 4.745482
+      },
+      "rotationOffset": 0.0,
+      "minWaypointRelativePos": 1.0,
+      "maxWaypointRelativePos": 1.65199799905838,
+      "name": "Point Towards Zone"
+    }
+  ],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 3.0,
+    "maxAcceleration": 3.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": -54.0
+  },
+  "reversed": false,
+  "folder": null,
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": -119.99999999999999
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/paths/lc4-top_coral-rev.path
+++ b/src/main/deploy/pathplanner/paths/lc4-top_coral-rev.path
@@ -1,0 +1,65 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 3.1625802357902417,
+        "y": 4.1930564580775815
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 2.7206804258240256,
+        "y": 4.98351979739346
+      },
+      "isLocked": false,
+      "linkedName": "lc4"
+    },
+    {
+      "anchor": {
+        "x": 1.5428857751794762,
+        "y": 7.3094875026393575
+      },
+      "prevControl": {
+        "x": 2.268268482105152,
+        "y": 7.004002256651182
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "top_coral-rev"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [
+    {
+      "fieldPosition": {
+        "x": 4.073905999999999,
+        "y": 4.745482
+      },
+      "rotationOffset": 0.0,
+      "minWaypointRelativePos": 1.0,
+      "maxWaypointRelativePos": 1.65199799905838,
+      "name": "Point Towards Zone"
+    }
+  ],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 3.0,
+    "maxAcceleration": 3.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": -54.0
+  },
+  "reversed": false,
+  "folder": null,
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 0.0
+  },
+  "useDefaultConstraints": true
+}


### PR DESCRIPTION
This will allow us to experiment with how much better our estimates robot
poses could be if our offseason 2025 robot did the outtake on the opposite
side as the intake.

For both new paths, the robot tries to point towards AprilTag 17 as it moves
towards the coral station.

Created by copying existing paths and making manual changes to change the
rotation for the goal and state, and changing/adding point towards zones.