### PR TITLE
Update to the latest commit of lib2813 

### DIFF
--- a/src/main/java/com/team2813/subsystems/Elevator.java
+++ b/src/main/java/com/team2813/subsystems/Elevator.java
@@ -16,7 +16,6 @@ import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.units.measure.Angle;
-import edu.wpi.first.units.measure.Current;
 import java.util.function.Supplier;
 
 /** This is the Elevator. His name is Pablo. Please be kind to him and say hi. Have a nice day! */
@@ -50,11 +49,6 @@ public class Elevator extends MotorSubsystem<Elevator.Position> {
   @Override
   protected void useOutput(double output, double setpoint) {
     super.useOutput(MathUtil.clamp(output, -6, 6), setpoint);
-  }
-
-  @Override
-  public Current getAppliedCurrent() {
-    return motor.getAppliedCurrent();
   }
 
   public enum Position implements Supplier<Angle> {

--- a/src/main/java/com/team2813/subsystems/GroundIntakePivot.java
+++ b/src/main/java/com/team2813/subsystems/GroundIntakePivot.java
@@ -17,7 +17,6 @@ import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.units.measure.Angle;
-import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.wpilibj.DriverStation;
 import java.util.function.Supplier;
 
@@ -53,11 +52,6 @@ public class GroundIntakePivot extends MotorSubsystem<GroundIntakePivot.Position
         new CurrentLimitsConfigs().withStatorCurrentLimit(40).withStatorCurrentLimitEnable(true));
 
     return pivotMotor;
-  }
-
-  @Override
-  public Current getAppliedCurrent() {
-    return motor.getAppliedCurrent();
   }
 
   @Override

--- a/src/main/java/com/team2813/subsystems/IntakePivot.java
+++ b/src/main/java/com/team2813/subsystems/IntakePivot.java
@@ -13,7 +13,6 @@ import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.units.measure.Angle;
-import edu.wpi.first.units.measure.Current;
 import java.util.function.Supplier;
 
 /**
@@ -44,11 +43,6 @@ public class IntakePivot extends MotorSubsystem<IntakePivot.Rotations> {
   @Override
   protected void useOutput(double output, double setPoint) {
     super.useOutput(output, setPoint);
-  }
-
-  @Override
-  public Current getAppliedCurrent() {
-    return motor.getAppliedCurrent();
   }
 
   private static PIDMotor pivotMotor() {


### PR DESCRIPTION
This includes the following:
- https://github.com/Prospect-Robotics/lib2813/pull/54
- https://github.com/Prospect-Robotics/lib2813/pull/55
- https://github.com/Prospect-Robotics/lib2813/pull/56
- https://github.com/Prospect-Robotics/lib2813/pull/58
- https://github.com/Prospect-Robotics/lib2813/pull/59
- https://github.com/Prospect-Robotics/lib2813/pull/60

Local changes:
- Remove now-redundant overrides of `MotorSubsystem.getAppliedCurrent()`